### PR TITLE
Generating a linux executable

### DIFF
--- a/alvis.head
+++ b/alvis.head
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+MYSELF=`which "${0}" 2>/dev/null`
+[ $? -gt 0 -a -f "${0}" ] && MYSELF="./${0}"
+JAVA=java
+if test -n "${JAVA_HOME}"; then
+    JAVA="${JAVA_HOME}/bin/java"
+fi
+
+JVM_OPTS=""
+OPTS=""
+
+while [[ $# -gt 0 ]]; do
+  case ${1} in
+    --JVM|--java)
+    JVM_OPTS="${JVM_OPTS} ${2}"
+    shift
+    shift
+    ;;
+    --help|-h|help)
+    OPTS="${OPTS} ${1}"
+    echo "You can pass Java options using --JVM \"<options>\""
+    echo "For example: ${0} --JVM \"-Xmx2G -Xms100m\""
+    shift
+    ;;
+    *)
+    OPTS="${OPTS} ${1}"
+    shift
+    ;;
+  esac
+done
+
+exec "${JAVA}" ${JVM_OPTS} -jar ${MYSELF} ${OPTS}
+exit 1

--- a/build.xml
+++ b/build.xml
@@ -20,6 +20,9 @@
     </target>
 
     <target name="linux-bin" depends="jar">
+        <exec executable="echo">
+        <arg value="Building linux executable: ${basedir}/alvis"/>
+        </exec>
         <concat destfile="${basedir}/alvis" binary="yes">
             <fileset file="${basedir}/alvis.head"/>
             <fileset file="dist/Alvis.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -19,6 +19,17 @@
         </jar>
     </target>
 
+    <target name="linux-bin" depends="jar">
+        <concat destfile="${basedir}/alvis" binary="yes">
+            <fileset file="${basedir}/alvis.head"/>
+            <fileset file="dist/Alvis.jar"/>
+        </concat>
+        <exec executable="chmod">
+        <arg value="755"/>
+        <arg value="${basedir}/alvis"/>
+        </exec>
+    </target>
+
     <target name="run">
         <java jar="dist/Alvis.jar" fork="true"/>
     </target>


### PR DESCRIPTION
Alvis is a really great tool, congrats to all involved.

I understand it is platform independent, but I thought it could benefit from being available as a a self-contained linux executable to avoid the `java -jar` especially if/when it ends up in containers. 

To build:

```sh
ant linux-bin
```

You might want to modify the bash wrapper as required.

